### PR TITLE
Updated GroupDocs.Viewer for .NET to 21.10

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>21.9.0</GroupDocsViewer>
+    <GroupDocsViewer>21.10.0</GroupDocsViewer>
     <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.2</SkiaSharpNativeAssetsLinuxNoDependencies>
 
     <MicrosoftExtensionsHttp>3.1.18</MicrosoftExtensionsHttp>
@@ -39,6 +39,6 @@
     <GroupDocsViewerUIApiInMemoryCache>3.1.0</GroupDocsViewerUIApiInMemoryCache>
     <GroupDocsViewerUIApiLocalStorage>3.1.1</GroupDocsViewerUIApiLocalStorage>
     <GroupDocsViewerUICore>3.1.2</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>3.1.6</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>3.1.7</GroupDocsViewerUISelfHostApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating [GroupDocs.Viewer for .NET](https://www.nuget.org/packages/groupdocs.viewer) package to 21.10.
Release notes: https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-21-10-release-notes/ 