### PR TITLE
Updated GroupDocs.Viewer for .NET to 21.11

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>21.10.0</GroupDocsViewer>
+    <GroupDocsViewer>21.11.0</GroupDocsViewer>
     <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.2</SkiaSharpNativeAssetsLinuxNoDependencies>
 
     <MicrosoftExtensionsHttp>3.1.18</MicrosoftExtensionsHttp>


### PR DESCRIPTION
[GroupDocs.Viewer for .NET 21.11](https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-21-11-release-notes/) become available with fixes and improvements. It's about time to update.