### PR TITLE
Added GroupDocs Cloud Storage

### DIFF
--- a/GroupDocs.Viewer.UI.sln
+++ b/GroupDocs.Viewer.UI.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GroupDocs.Viewer.UI.Cloud.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GroupDocs.Viewer.UI.Cloud.Api", "src\GroupDocs.Viewer.UI.Cloud.Api\GroupDocs.Viewer.UI.Cloud.Api.csproj", "{4D3FDAC3-52A6-4CD3-B6C9-1A2BF5778319}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GroupDocs.Viewer.UI.Api.Cloud.Storage", "src\GroupDocs.Viewer.UI.Api.Cloud.Storage\GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj", "{A59FCB54-07FE-48DE-A727-39678BF90D4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -176,6 +178,18 @@ Global
 		{4D3FDAC3-52A6-4CD3-B6C9-1A2BF5778319}.Release|x64.Build.0 = Release|Any CPU
 		{4D3FDAC3-52A6-4CD3-B6C9-1A2BF5778319}.Release|x86.ActiveCfg = Release|Any CPU
 		{4D3FDAC3-52A6-4CD3-B6C9-1A2BF5778319}.Release|x86.Build.0 = Release|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Release|x64.Build.0 = Release|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -192,6 +206,7 @@ Global
 		{65E53DB7-C692-4DBF-8B62-96A28A41C02B} = {98234968-D728-4D2D-B985-88A63DF6541A}
 		{511A4794-084A-4688-A3BF-CBA52ACCADE7} = {98234968-D728-4D2D-B985-88A63DF6541A}
 		{4D3FDAC3-52A6-4CD3-B6C9-1A2BF5778319} = {F01C54A8-0505-4D3F-B12C-FEB3F827509E}
+		{A59FCB54-07FE-48DE-A727-39678BF90D4A} = {F01C54A8-0505-4D3F-B12C-FEB3F827509E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D7F2C427-C9AB-4B55-B1F9-C41195D7CD6C}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,14 @@ This code registers **/viewer** middleware that will serve SPA and **/viewer-api
 
 ## UI
 
-The UI is Angular SPA that is build upon [@groupdocs.examples.angular/viewer](https://www.npmjs.com/package/@groupdocs.examples.angular/viewer) package.
+The UI is Angular SPA that is build upon [@groupdocs.examples.angular/viewer](https://www.npmjs.com/package/@groupdocs.examples.angular/viewer) package. You can change the path where the SPA will be available by setting `UIPath` property e.g.
+
+```cs
+endpoints.MapGroupDocsViewerUI(options =>
+{
+    options.UIPath = "/my-viewer-app";
+});
+```
 
 ### Changing UI Language
 
@@ -160,16 +167,41 @@ As an example the following commands should be executed to install the dependenc
 Storage providers are used to read/write file from/to the storage. The storage provider is mandatory.
 
 - [GroupDocs.Viewer.UI.Api.Local.Storage](https://www.nuget.org/packages/GroupDocs.Viewer.UI.Api.Local.Storage)
+- [GroupDocs.Viewer.UI.Api.Cloud.Storage](https://www.nuget.org/packages/GroupDocs.Viewer.UI.Api.Cloud.Storage)
 
 All the storage providers are extensions of `GroupDocsViewerUIApiBuilder`:
 
 #### Local Storage
+
+To render files from your local drive use local file storage.
 
 ```cs
 services
     .AddControllers()
     .AddGroupDocsViewerSelfHostApi()
     .AddLocalStorage("./Files");
+```
+
+#### Cloud Storage
+
+When rendering files using [GroupDocs Cloud](https://dashboard.groupdocs.cloud/) infrastructure it is reasonable to opt to cloud storage provider. GroupDocs Cloud storage supports number of 3d-party storages including Amazon S3, Google Drive and Cloud, Azure, Dropbox, Box, and FTP. To start using GroupDocs Cloud get your `Client ID` and `Client Secret` at <https://dashboard.groupdocs.cloud/applications>.
+
+```cs
+var clientId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var clientSecret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+services
+    .AddControllers()
+    .AddGroupDocsViewerCloudApi(config => 
+        config
+            .SetClientId(clientId)
+            .SetClientSecret(clientSecret)
+    )
+    .AddCloudStorage(config => 
+        config
+            .SetClientId(clientId)
+            .SetClientSecret(clientSecret)
+    )
 ```
 
 ### API Cache Providers

--- a/build.ps1
+++ b/build.ps1
@@ -54,4 +54,5 @@ exec { & dotnet pack .\src\GroupDocs.Viewer.UI.SelfHost.Api\GroupDocs.Viewer.UI.
 exec { & dotnet pack .\src\GroupDocs.Viewer.UI.Cloud.Api\GroupDocs.Viewer.UI.Cloud.Api.csproj -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
 exec { & dotnet pack .\src\GroupDocs.Viewer.UI.Api.Local.Cache\GroupDocs.Viewer.UI.Api.Local.Cache.csproj -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
 exec { & dotnet pack .\src\GroupDocs.Viewer.UI.Api.InMemory.Cache\GroupDocs.Viewer.UI.Api.InMemory.Cache.csproj -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
+exec { & dotnet pack .\src\GroupDocs.Viewer.UI.Api.Cloud.Storage\GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
 exec { & dotnet pack .\src\GroupDocs.Viewer.UI.Api.Local.Storage\GroupDocs.Viewer.UI.Api.Local.Storage.csproj -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -38,6 +38,7 @@
     <GroupDocsViewerUIApiLocalCache>3.1.3</GroupDocsViewerUIApiLocalCache>
     <GroupDocsViewerUIApiInMemoryCache>3.1.1</GroupDocsViewerUIApiInMemoryCache>
     <GroupDocsViewerUIApiLocalStorage>3.1.2</GroupDocsViewerUIApiLocalStorage>
+    <GroupDocsViewerUIApiCloudStorage>3.1.0</GroupDocsViewerUIApiCloudStorage>
     <GroupDocsViewerUICore>3.1.3</GroupDocsViewerUICore>
     <GroupDocsViewerUISelfHostApi>3.1.8</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>3.1.0</GroupDocsViewerUICloudApi>

--- a/samples/GroupDocs.Viewer.UI.Cloud.Api.Sample/GroupDocs.Viewer.UI.Cloud.Api.Sample.csproj
+++ b/samples/GroupDocs.Viewer.UI.Cloud.Api.Sample/GroupDocs.Viewer.UI.Cloud.Api.Sample.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\GroupDocs.Viewer.UI\GroupDocs.Viewer.UI.csproj" />
     <ProjectReference Include="..\..\src\GroupDocs.Viewer.UI.Api\GroupDocs.Viewer.UI.Api.csproj" />
     <ProjectReference Include="..\..\src\GroupDocs.Viewer.UI.Api.Local.Cache\GroupDocs.Viewer.UI.Api.Local.Cache.csproj" />
-    <ProjectReference Include="..\..\src\GroupDocs.Viewer.UI.Api.Local.Storage\GroupDocs.Viewer.UI.Api.Local.Storage.csproj" />
+    <ProjectReference Include="..\..\src\GroupDocs.Viewer.UI.Api.Cloud.Storage\GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GroupDocs.Viewer.UI.Cloud.Api.Sample/Startup.cs
+++ b/samples/GroupDocs.Viewer.UI.Cloud.Api.Sample/Startup.cs
@@ -15,16 +15,23 @@ namespace GroupDocs.Viewer.UI.Cloud.Api.Sample
                 .AddGroupDocsViewerUI(config => 
                     config.SetViewerType(viewerType));
 
+            // Get your Client ID and Client Secret at https://dashboard.groupdocs.cloud/applications
+            var clientId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+            var clientSecret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
             services
                 .AddControllers()
                 .AddGroupDocsViewerCloudApi(config => 
-                    // Get your Client ID and Client Secret at https://dashboard.groupdocs.cloud/applications
                     config
-                        .SetClientId("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-                        .SetClientSecret("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                        .SetClientId(clientId)
+                        .SetClientSecret(clientSecret)
                         .SetViewerType(viewerType)
                 )
-                .AddLocalStorage("./Files")
+                .AddCloudStorage(config => 
+                    config
+                        .SetClientId(clientId)
+                        .SetClientSecret(clientSecret)
+                )
                 .AddLocalCache("./Cache");
         }
 

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/AuthServerConnect.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/AuthServerConnect.cs
@@ -1,0 +1,43 @@
+﻿using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect
+{
+    internal class AuthServerConnect : IAuthServerConnect
+    {
+        private readonly HttpClient _httpClient;
+        private readonly Config _config;
+
+        public AuthServerConnect(HttpClient httpClient, IOptions<Config> config)
+        {
+            _httpClient = httpClient;
+            _config = config.Value;
+        }
+
+        public async Task<string> RequestClientCredentialsTokenAsync()
+        {
+            var content = new StringContent(
+                $"grant_type=client_credentials&client_id={_config.ClientId}&client_secret={_config.ClientSecret}",
+                Encoding.UTF8,
+                "application/x-www-form-urlencoded");
+
+            var response = await _httpClient.PostAsync("/connect/token", content);
+            var json = await response.Content.ReadAsStringAsync();
+
+            var result = JsonSerializer.Deserialize<GetAccessTokenResult>(json);
+            var token = result.access_token;
+
+            return token;
+        }
+
+        private class GetAccessTokenResult
+        {
+            public string access_token { get; set; }
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Contracts/IAuthServerConnect.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Contracts/IAuthServerConnect.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts
+{
+    /// <summary>
+    /// Auth API
+    /// </summary>
+    internal interface IAuthServerConnect
+    {
+        /// <summary>
+        /// Requests client credentials Bearer token 
+        /// </summary>
+        /// <returns>Bearer token</returns>
+        Task<string> RequestClientCredentialsTokenAsync();
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Contracts/IStorageApiConnect.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Contracts/IStorageApiConnect.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.Common;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts
+{
+    /// <summary>
+    /// Viewer API
+    /// </summary>
+    public interface IStorageApiConnect
+    {
+        Task<Result<bool>> CheckObjectExistsAsync(ObjectExistRequest request);
+
+        Task<Result<FilesList>> GetFilesList(GetFilesListRequest request);
+
+        Task<Result<byte[]>> DownloadFile(DownloadFileRequest request);
+
+        Task<Result> UploadFile(UploadFileRequest request);
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Extensions/HttpClientMessageExtensions.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Extensions/HttpClientMessageExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Extensions
+{
+    internal static class HttpClientMessageExtensions
+    {
+        /// <summary>
+        /// Sets an authorization header with a given scheme and value.
+        /// </summary>
+        /// <param name="request">The HTTP request message.</param>
+        /// <param name="scheme">The scheme.</param>
+        /// <param name="token">The token.</param>
+        public static void SetToken(this HttpRequestMessage request, string scheme, string token)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(scheme, token);
+        }
+
+        /// <summary>
+        /// Sets an authorization header with a bearer token.
+        /// </summary>
+        /// <param name="request">The HTTP request message.</param>
+        /// <param name="token">The token.</param>
+        public static void SetBearerToken(this HttpRequestMessage request, string token)
+        {
+            request.SetToken("Bearer", token);
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Handlers/ProtectedApiBearerTokenHandler.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Handlers/ProtectedApiBearerTokenHandler.cs
@@ -1,0 +1,30 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Extensions;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Handlers
+{
+    internal class ProtectedApiBearerTokenHandler : DelegatingHandler
+    {
+        private readonly IAuthServerConnect _authServerConnect;
+
+        public ProtectedApiBearerTokenHandler(IAuthServerConnect authServerConnect)
+        {
+            _authServerConnect = authServerConnect;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // request the access token
+            var accessToken = await _authServerConnect.RequestClientCredentialsTokenAsync();
+
+            // set the bearer token to the outgoing request as Authentication Header
+            request.SetBearerToken(accessToken);
+
+            // Proceed calling the inner handler, that will actually send the requestto our protected api
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/DownloadFileRequest.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/DownloadFileRequest.cs
@@ -1,0 +1,36 @@
+﻿namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests
+{
+    /// <summary>
+    /// Request model for download file operation.
+    /// </summary>  
+    public class DownloadFileRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DownloadFileRequest"/> class.
+        /// </summary>        
+        public DownloadFileRequest()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DownloadFileRequest"/> class.
+        /// </summary>
+        /// <param name="path">File path e.g. '/folder/file.ext'</param>
+        /// <param name="storageName">Storage name</param>
+        public DownloadFileRequest(string path, string storageName = null)
+        {
+            this.Path = path;
+            this.StorageName = storageName;
+        }
+
+        /// <summary>
+        /// File path e.g. '/folder/file.ext'
+        /// </summary>  
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Storage name
+        /// </summary>  
+        public string StorageName { get; set; }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/GetFilesListRequest.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/GetFilesListRequest.cs
@@ -1,0 +1,36 @@
+﻿namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests
+{
+    /// <summary>
+    /// Get files list request model.
+    /// </summary>  
+    public class GetFilesListRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetFilesListRequest"/> class.
+        /// </summary>        
+        public GetFilesListRequest()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetFilesListRequest"/> class.
+        /// </summary>
+        /// <param name="path">Folder path e.g. &#39;/folder&#39;</param>
+        /// <param name="storageName">Storage name</param>
+        public GetFilesListRequest(string path, string storageName = null)
+        {
+            this.Path = path;
+            this.StorageName = storageName;
+        }
+
+        /// <summary>
+        /// Folder path e.g. '/folder'
+        /// </summary>  
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Storage name
+        /// </summary>  
+        public string StorageName { get; set; }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/ObjectExistRequest.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/ObjectExistRequest.cs
@@ -1,0 +1,36 @@
+﻿namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests
+{
+    /// <summary>
+    /// Request model for download file operation.
+    /// </summary>  
+    public class ObjectExistRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectExistRequest"/> class.
+        /// </summary>        
+        public ObjectExistRequest()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectExistRequest"/> class.
+        /// </summary>
+        /// <param name="path">File path e.g. '/folder/file.ext'</param>
+        /// <param name="storageName">Storage name</param>
+        public ObjectExistRequest(string path, string storageName = null)
+        {
+            this.Path = path;
+            this.StorageName = storageName;
+        }
+
+        /// <summary>
+        /// File path e.g. '/folder/file.ext'
+        /// </summary>  
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Storage name
+        /// </summary>  
+        public string StorageName { get; set; }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/UploadFileRequest.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Requests/UploadFileRequest.cs
@@ -1,0 +1,40 @@
+﻿namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests
+{
+    /// <summary>
+    /// Request model for download file operation.
+    /// </summary>  
+    public class UploadFileRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UploadFileRequest"/> class.
+        /// </summary>        
+        public UploadFileRequest()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UploadFileRequest"/> class.
+        /// </summary>
+        /// <param name="fileName">File path e.g. '/folder/file.ext'</param>
+        /// <param name="data">File bytes</param>
+        /// <param name="storageName">Storage name</param>
+        public UploadFileRequest(string fileName, byte[] data, string storageName = null)
+        {
+            this.FileName = fileName;
+            this.Data = data;
+            this.StorageName = storageName;
+        }
+
+        public byte[] Data { get; set; }
+
+        /// <summary>
+        /// File path e.g. '/folder/file.ext'
+        /// </summary>  
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Storage name
+        /// </summary>  
+        public string StorageName { get; set; }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/Error.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/Error.cs
@@ -1,0 +1,46 @@
+using System.Text;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses
+{
+    /// <summary>
+    /// Error model
+    /// </summary>  
+    public class Error
+    {
+        /// <summary>
+        /// Code             
+        /// </summary>  
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Message             
+        /// </summary>  
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Description             
+        /// </summary>  
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Inner Error             
+        /// </summary>  
+        public ErrorDetails InnerError { get; set; }
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class Error {\n");
+            sb.Append("  Code: ").Append(this.Code).Append("\n");
+            sb.Append("  Message: ").Append(this.Message).Append("\n");
+            sb.Append("  Description: ").Append(this.Description).Append("\n");
+            sb.Append("  InnerError: ").Append(this.InnerError).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/ErrorDetails.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/ErrorDetails.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Text;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses
+{
+    /// <summary>
+    /// The error details
+    /// </summary>  
+    public class ErrorDetails
+    {
+        /// <summary>
+        /// The request id
+        /// </summary>  
+        public string RequestId { get; set; }
+
+        /// <summary>
+        /// Date
+        /// </summary>  
+        public DateTime Date { get; set; }
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class ErrorDetails {\n");
+            sb.Append("  RequestId: ").Append(this.RequestId).Append("\n");
+            sb.Append("  Date: ").Append(this.Date).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/FilesList.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/FilesList.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses
+{
+    /// <summary>
+    /// Files list
+    /// </summary>  
+    public class FilesList
+    {
+        /// <summary>
+        /// Files and folders contained by folder StorageFile.
+        /// </summary>  
+        public List<StorageFile> Value { get; set; } = new List<StorageFile>();
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class FilesList {\n");
+            sb.Append("  Value: ").Append(this.Value).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/StorageFile.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/StorageFile.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses
+{
+    /// <summary>
+    /// File or folder information
+    /// </summary>  
+    public class StorageFile
+    {
+        /// <summary>
+        /// File or folder name.
+        /// </summary>  
+        public string Name { get; set; }
+
+        /// <summary>
+        /// True if it is a folder.
+        /// </summary>  
+        public bool IsFolder { get; set; }
+
+        /// <summary>
+        /// File or folder last modified DateTime.
+        /// </summary>  
+        public DateTime ModifiedDate { get; set; }
+
+        /// <summary>
+        /// File or folder size.
+        /// </summary>  
+        public long Size { get; set; }
+
+        /// <summary>
+        /// File or folder path.
+        /// </summary>  
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class StorageFile {\n");
+            sb.Append("  Name: ").Append(this.Name).Append("\n");
+            sb.Append("  IsFolder: ").Append(this.IsFolder).Append("\n");
+            sb.Append("  ModifiedDate: ").Append(this.ModifiedDate).Append("\n");
+            sb.Append("  Size: ").Append(this.Size).Append("\n");
+            sb.Append("  Path: ").Append(this.Path).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/UploadedFiles.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/Responses/UploadedFiles.cs
@@ -1,0 +1,60 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright company="Aspose Pty Ltd" file="FilesUploadResult.cs">
+//  Copyright (c) 2003-2021 Aspose Pty Ltd
+// </copyright>
+// <summary>
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+// 
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+// 
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses 
+{
+    /// <summary>
+    /// File upload result
+    /// </summary>  
+    public class UploadedFiles
+    {
+        /// <summary>
+        /// List of uploaded file names
+        /// </summary>  
+        public List<string> Uploaded { get; set; } = new List<string>();
+
+        /// <summary>
+        /// List of errors.
+        /// </summary>  
+        public List<Error> Errors { get; set; } = new List<Error>();
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()  
+        {
+          var sb = new StringBuilder();
+          sb.Append("class FilesUploadResult {\n");
+          sb.Append("  Uploaded: ").Append(this.Uploaded).Append("\n");
+          sb.Append("  Errors: ").Append(this.Errors).Append("\n");
+          sb.Append("}\n");
+          return sb.ToString();
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/StorageApiConnect.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/ApiConnect/StorageApiConnect.cs
@@ -1,0 +1,215 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Responses;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.Common;
+using Newtonsoft.Json;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect
+{
+    internal class StorageApiConnect : IStorageApiConnect
+    {
+        private readonly HttpClient _httpClient;
+
+        private readonly JsonSerializerSettings _jsonSerializerSettings
+            = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+
+        public StorageApiConnect(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<Result<FilesList>> GetFilesList(GetFilesListRequest request)
+        {
+            var uri = $"viewer/storage/folder/{request.Path}?storageName={request.StorageName}";
+            Result<FilesList> result = await Send<FilesList>(uri, HttpMethod.Get);
+
+            return result;
+        }
+
+        public async Task<Result<byte[]>> DownloadFile(DownloadFileRequest request)
+        {
+            var requestUri = $"viewer/storage/file/{request.Path}?storageName={request.StorageName}";
+            Result<byte[]> result = await Download<FilesList>(requestUri);
+
+            return result;
+        }
+
+        public async Task<Result> UploadFile(UploadFileRequest request)
+        {
+            var requestUri = $"viewer/storage/file/{request.FileName}?storageName={request.StorageName}";
+            var uploadResult = await Upload<UploadedFiles>(requestUri, request.Data);
+            if (uploadResult.IsFailure)
+                return Result.Fail(uploadResult.Message);
+
+            if (uploadResult.Value.Errors.Any())
+                return Result.Fail(string.Join("; ", uploadResult.Value.Errors));
+
+            return Result.Ok();
+        }
+
+        public async Task<Result<bool>> CheckObjectExistsAsync(ObjectExistRequest request)
+        {
+            var requestUri = $"viewer/storage/exist/{request.Path}?storageName={request.StorageName}";
+            var existResult = await Send<ObjectExist>(requestUri, HttpMethod.Get);
+
+            if (existResult.IsFailure)
+                return Result.Fail<bool>(existResult);
+
+            return Result.Ok(existResult.Value.Exists);
+        }
+
+        private async Task<Result<T>> Send<T>(string requestUri, HttpMethod method, object request = null)
+        {
+            var message = new HttpRequestMessage(method, requestUri);
+
+            if (request != null)
+            {
+                var requestJson = JsonConvert.SerializeObject(request, _jsonSerializerSettings);
+                message.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            }
+
+            var response = await _httpClient.SendAsync(message);
+            var responseJson = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                if (TryDeserialize(responseJson, out ErrorResult errorResponse)
+                    && errorResponse.Error != null)
+                    return Result.Fail<T>(errorResponse.Error.Message);
+
+                if (TryDeserialize(responseJson, out Error error)
+                    && error.Message != null)
+                    return Result.Fail<T>(error.Message);
+
+                return Result.Fail<T>(responseJson);
+            }
+
+            var obj = JsonConvert.DeserializeObject<T>(responseJson, _jsonSerializerSettings);
+            return Result.Ok(obj);
+        }
+
+        private async Task<Result<T>> Upload<T>(string requestUri, byte[] data)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Put, requestUri);
+            message.Content = new ByteArrayContent(data);
+
+            var response = await _httpClient.SendAsync(message);
+            var responseJson = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                if (TryDeserialize(responseJson, out ErrorResult errorResponse)
+                    && errorResponse.Error != null)
+                    return Result.Fail<T>(errorResponse.Error.Message);
+
+                if (TryDeserialize(responseJson, out Error error)
+                    && error.Message != null)
+                    return Result.Fail<T>(error.Message);
+
+                return Result.Fail<T>(responseJson);
+            }
+
+            var obj = JsonConvert.DeserializeObject<T>(responseJson, _jsonSerializerSettings);
+            return Result.Ok(obj);
+        }
+
+        private async Task<Result<byte[]>> Download<T>(string requestUri)
+        {
+            var response = await _httpClient.GetAsync(requestUri);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseJson = await response.Content.ReadAsStringAsync();
+
+                if (TryDeserialize(responseJson, out ErrorResult errorResponse)
+                    && errorResponse.Error != null)
+                    return Result.Fail<byte[]>(errorResponse.Error.Message);
+
+                if (TryDeserialize(responseJson, out Error error)
+                    && error.Message != null)
+                    return Result.Fail<byte[]>(error.Message);
+
+                return Result.Fail<byte[]>(responseJson);
+            }
+
+            var bytes = await response.Content.ReadAsByteArrayAsync();
+            return Result.Ok(bytes);
+        }
+
+        private bool TryDeserialize<T>(string json, out T obj)
+        {
+            try
+            {
+                obj = JsonConvert.DeserializeObject<T>(json, _jsonSerializerSettings);
+            }
+            catch (JsonSerializationException)
+            {
+                obj = default(T);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// The error result
+    /// </summary>  
+    public class ErrorResult
+    {
+        /// <summary>
+        /// The error
+        /// </summary>
+        public Error Error { get; set; }
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class ErrorResult {\n");
+            sb.Append("  Error: ").Append(this.Error).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Object exists
+    /// </summary>  
+    public class ObjectExist
+    {
+        /// <summary>
+        /// Indicates that the file or folder exists.
+        /// </summary>  
+        public bool Exists { get; set; }
+
+        /// <summary>
+        /// True if it is a folder, false if it is a file.
+        /// </summary>  
+        public bool IsFolder { get; set; }
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class ObjectExist {\n");
+            sb.Append("  Exists: ").Append(this.Exists).Append("\n");
+            sb.Append("  IsFolder: ").Append(this.IsFolder).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/CloudFileStorage.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/CloudFileStorage.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Requests;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.Configuration;
+using GroupDocs.Viewer.UI.Core;
+using GroupDocs.Viewer.UI.Core.Entities;
+using Microsoft.Extensions.Options;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage
+{
+    public class CloudFileStorage : IFileStorage
+    {
+        private readonly Config _config;
+        private readonly IStorageApiConnect _apiConnect;
+
+        public CloudFileStorage(IOptions<Config> config, IStorageApiConnect apiConnect)
+        {
+            _apiConnect = apiConnect;
+            _config = config.Value;
+        }
+
+        public async Task<IEnumerable<FileSystemEntry>> ListDirsAndFilesAsync(string dirPath)
+        {
+            var request = new GetFilesListRequest(dirPath, _config.StorageName);
+            var result = await _apiConnect.GetFilesList(request);
+
+            if (result.IsFailure)
+                throw new Exception(result.Message);
+
+            var entries = result.Value.Value
+                .Select(file => file.IsFolder
+                    ? FileSystemEntry.Directory(file.Name, file.Path, file.Size)
+                    : FileSystemEntry.File(file.Name, file.Path, file.Size))
+                .ToList();
+
+            return entries;
+        }
+
+        public async Task<byte[]> ReadFileAsync(string filePath)
+        {
+            var request = new DownloadFileRequest(filePath, _config.StorageName);
+            var result = await _apiConnect.DownloadFile(request);
+
+            if (result.IsFailure)
+                throw new Exception(result.Message);
+
+            return result.Value;
+        }
+
+        public async Task<string> WriteFileAsync(string fileName, byte[] bytes, bool rewrite)
+        {
+            if (!rewrite)
+                fileName = await GetFreeFileName(fileName);
+
+            var request = new UploadFileRequest(fileName, bytes, _config.StorageName);
+            var result = await _apiConnect.UploadFile(request);
+            if (result.IsFailure)
+                throw new Exception(result.Message);
+
+            return fileName;
+        }
+
+        private async Task<string> GetFreeFileName(string fileName)
+        {
+            var exist = await FileExists(fileName);
+            if (!exist) return fileName;
+
+            var fileNameWithExtension = Path.GetFileName(fileName);
+            var dirPath = fileName.Replace(fileNameWithExtension, string.Empty);
+            var dirFiles = await ListDirsAndFilesAsync(dirPath);
+
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+            var number = 1;
+            string fileNameCandidate;
+            do
+            {
+                string newFileName = $"{fileNameWithoutExtension} ({number})";
+                fileNameCandidate = fileName.Replace(fileNameWithoutExtension, newFileName);
+                number++;
+            } while (dirFiles.Any(dirFile => 
+                dirFile.FileName.Equals(fileNameCandidate, StringComparison.InvariantCultureIgnoreCase)));
+
+            return fileNameCandidate;
+        }
+
+        private async Task<bool> FileExists(string fileName)
+        {
+            var request = new ObjectExistRequest(fileName, _config.StorageName);
+            var result = await _apiConnect.CheckObjectExistsAsync(request);
+
+            if (result.IsFailure)
+                throw new Exception(result.Message);
+
+            return result.Value;
+
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Common/Result.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Common/Result.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.Common
+{
+    public class Result
+    {
+        public bool IsSuccess { get; }
+       
+        public string Message { get; }
+     
+        public bool IsFailure => !IsSuccess;
+
+        protected Result(bool isSuccess, string message)
+        {
+            if (isSuccess && message != string.Empty)
+                throw new InvalidOperationException();
+            if (!isSuccess && message == string.Empty)
+                throw new InvalidOperationException();
+
+            IsSuccess = isSuccess;
+            Message = message;
+        }
+
+        public static Result<T> Fail<T>(string message)
+        {
+            return new Result<T>(default(T), false, message);
+        }
+
+        public static Result<T> Fail<T>(Result result)
+        {
+            return new Result<T>(default(T), false, result.Message);
+        }
+
+        public static Result Fail(string message)
+        {
+            return new Result(false, message);
+        }
+
+        public static Result Ok()
+        {
+            return new Result(true, string.Empty);
+        }
+
+        public static Result<T> Ok<T>(T value)
+        {
+            return new Result<T>(value, true, string.Empty);
+        }
+    }
+
+    public class Result<T> : Result
+    {
+        private readonly T _value;
+
+        public T Value
+        {
+            get
+            {
+                if (!IsSuccess)
+                    throw new InvalidOperationException();
+
+                return _value;
+            }
+        }
+
+        protected internal Result(T value, bool isSuccess, string message)
+            : base(isSuccess, message)
+        {
+            _value = value;
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Configuration/Config.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Configuration/Config.cs
@@ -1,0 +1,55 @@
+﻿namespace GroupDocs.Viewer.UI.Api.Cloud.Storage.Configuration
+{
+    public class Config
+    {
+        internal string ApiEndpoint = "https://api.groupdocs.cloud/v2.0/";
+        internal string ClientId = string.Empty;
+        internal string ClientSecret = string.Empty;
+        internal string StorageName = string.Empty;
+
+        /// <summary>
+        /// Setup the API endpoint. By default it is "https://api-qa.groupdocs.cloud/v2.0/".
+        /// </summary>
+        /// <param name="apiEndpoint">GroupDocs.Viewer Cloud API endpoint.</param>
+        /// <returns>This instance</returns>
+        public Config SetApiEndpoint(string apiEndpoint)
+        {
+            ApiEndpoint = apiEndpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// The client ID, get it at https://dashboard.groupdocs.cloud/applications
+        /// </summary>
+        /// <param name="clientId">The client ID</param>
+        /// <returns>This instance</returns>
+        public Config SetClientId(string clientId)
+        {
+            ClientId = clientId;
+            return this;
+        }
+
+        /// <summary>
+        /// The client secret, get it at https://dashboard.groupdocs.cloud/applications
+        /// </summary>
+        /// <param name="clientSecret">The secret</param>
+        /// <returns>This instance</returns>
+        public Config SetClientSecret(string clientSecret)
+        {
+            ClientSecret = clientSecret;
+            return this;
+        }
+
+        /// <summary>
+        /// Set storage name, you can find storage list at https://dashboard.groupdocs.cloud/storages.
+        /// When not set default storage is used.
+        /// </summary>
+        /// <param name="storageName">The storage name</param>
+        /// <returns>This instance</returns>
+        public Config SetStorageName(string storageName)
+        {
+            StorageName = storageName;
+            return this;
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Extensions/ConfigurationExtensions.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,19 @@
+using GroupDocs.Viewer.UI.Api.Cloud.Storage;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.Configuration;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Configuration
+{
+    public static class ConfigurationExtensions
+    {
+        public static Config BindCloudApiSettings
+            (this IConfiguration configuration, Config config)
+        {
+            configuration
+                .GetSection(Keys.GROUPDOCSVIEWERUI_API_CLOUD_STORAGE_SECTION_SETTING_KEY)
+                .Bind(config, c => c.BindNonPublicProperties = true);
+
+            return config;
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetFrameworkVersion)</TargetFramework>
+
+    <PackageId>GroupDocs.Viewer.UI.Api.Cloud.Storage</PackageId>
+    <Version>$(GroupDocsViewerUIApiCloudStorage)</Version>
+    <Description>GroupDocs.Viewer.UI.Api.Cloud.Storage containing cloud file-storage implementation that can be used with GroupDocs.Viewer.UI.Api see https://github.com/groupdocs-viewer/GroupDocs.Viewer-for-.NET-UI for more details.</Description>
+    <PackageTags>GroupDocs;Viewer;UI;API;Cloud;File;Storage;ASP.NET Core;</PackageTags>
+    <PackageIcon>images\icon.png</PackageIcon>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCore)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GroupDocs.Viewer.UI.Core\GroupDocs.Viewer.UI.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/GroupDocsViewerUIApiBuilderExtensions.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/GroupDocsViewerUIApiBuilderExtensions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Net.Http.Headers;
+using GroupDocs.Viewer.UI.Core;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Contracts;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.ApiConnect.Handlers;
+using GroupDocs.Viewer.UI.Api.Cloud.Storage.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class GroupDocsViewerUIApiBuilderExtensions
+    {
+        public static GroupDocsViewerUIApiBuilder AddCloudStorage(
+            this GroupDocsViewerUIApiBuilder builder, Action<Config> setupConfig)
+        {
+            if (setupConfig == null)
+                throw new ArgumentNullException(nameof(setupConfig));
+
+            var config = new Config();
+            setupConfig.Invoke(config);
+
+            //Add config options and bind configuration
+            builder.Services
+                .AddOptions<Config>()
+                .Configure<IConfiguration>((settings, configuration) =>
+                {
+                    configuration.BindCloudApiSettings(settings);
+                    setupConfig.Invoke(settings);
+                });
+
+            //Register custom Bearer Token Handler. The DelegatingHandler has to be registered as a Transient Service
+            builder.Services.AddTransient<ProtectedApiBearerTokenHandler>();
+
+            //Register a Typed Instance of HttpClientFactory for a Protected Resource
+            //More info see: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1
+            builder.Services.AddHttpClient<IStorageApiConnect, StorageApiConnect>(client =>
+                {
+                    client.BaseAddress = new Uri(config.ApiEndpoint);
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(
+                        new MediaTypeWithQualityHeaderValue("application/json"));
+                })
+                .AddHttpMessageHandler<ProtectedApiBearerTokenHandler>();
+
+            builder.Services.AddHttpClient<IAuthServerConnect, AuthServerConnect>(
+                "StorageAuthServerConnect", client =>
+            {
+                client.BaseAddress = new Uri(config.ApiEndpoint);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue("application/json"));
+            });
+
+            builder.Services.AddTransient<IFileStorage, CloudFileStorage>();
+
+            return builder;
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Keys.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/Keys.cs
@@ -1,0 +1,8 @@
+﻿namespace GroupDocs.Viewer.UI.Api.Cloud.Storage
+{
+    internal class Keys
+    {
+        public const string GROUPDOCSVIEWERUI_API_CLOUD_STORAGE_SECTION_SETTING_KEY = 
+            "GroupDocsViewerUIApiCloudStorage";
+    }
+}

--- a/src/GroupDocs.Viewer.UI.Api.Local.Storage/GroupDocsViewerUIApiBuilderExtensions.cs
+++ b/src/GroupDocs.Viewer.UI.Api.Local.Storage/GroupDocsViewerUIApiBuilderExtensions.cs
@@ -5,9 +5,11 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class GroupDocsViewerUIApiBuilderExtensions
     {
-        public static GroupDocsViewerUIApiBuilder AddLocalStorage(this GroupDocsViewerUIApiBuilder builder, string storagePath)
+        public static GroupDocsViewerUIApiBuilder AddLocalStorage(
+            this GroupDocsViewerUIApiBuilder builder, string storagePath)
         {
-            builder.Services.AddTransient<IFileStorage>(_ => new LocalFileStorage(storagePath));
+            builder.Services.AddTransient<IFileStorage>(_ => 
+                new LocalFileStorage(storagePath));
 
             return builder;
         }


### PR DESCRIPTION
This PR adds support for [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud/storages).
GroupDocs Cloud storage supports a number of 3d-party storage including:
* Amazon S3
* Google Drive and Cloud
* Azure
* Dropbox
* Box,
* and FTP

To start using GroupDocs Cloud get your `Client ID` and `Client Secret` at <https://dashboard.groupdocs.cloud/applications>