### PR TITLE
Updated GroupDocs.Viewer for .NET to 21.12

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>21.11.0</GroupDocsViewer>
+    <GroupDocsViewer>21.12.0</GroupDocsViewer>
     <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.2</SkiaSharpNativeAssetsLinuxNoDependencies>
 
     <MicrosoftExtensionsHttp>3.1.18</MicrosoftExtensionsHttp>
@@ -40,7 +40,7 @@
     <GroupDocsViewerUIApiLocalStorage>3.1.2</GroupDocsViewerUIApiLocalStorage>
     <GroupDocsViewerUIApiCloudStorage>3.1.0</GroupDocsViewerUIApiCloudStorage>
     <GroupDocsViewerUICore>3.1.3</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>3.1.8</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>3.1.9</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>3.1.0</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
GroupDocs.Viewer for .NET has been updated to the latest version 21.12. 

Release notes: https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-21-12-release-notes/
