### PR TITLE
Updated GroupDocs.Viewer to 22.1.1

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>21.12.0</GroupDocsViewer>
-    <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.2</SkiaSharpNativeAssetsLinuxNoDependencies>
+    <GroupDocsViewer>22.1.1</GroupDocsViewer>
+    <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.3</SkiaSharpNativeAssetsLinuxNoDependencies>
 
     <MicrosoftExtensionsHttp>3.1.18</MicrosoftExtensionsHttp>
     <MicrosoftAspNetCoreMvcCore>2.2.5</MicrosoftAspNetCoreMvcCore>
@@ -40,7 +40,7 @@
     <GroupDocsViewerUIApiLocalStorage>3.1.2</GroupDocsViewerUIApiLocalStorage>
     <GroupDocsViewerUIApiCloudStorage>3.1.0</GroupDocsViewerUIApiCloudStorage>
     <GroupDocsViewerUICore>3.1.3</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>3.1.9</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>3.1.10</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>3.1.0</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
GroupDocs.Viewer for .NET has been updated to the latest version 22.1.1

Release notes: 
* https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-22-1-release-notes/
* https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-22-1-1-release-notes/