### PR TITLE
Added IPageFormatter interface to provide a way to post-process pages

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -39,8 +39,8 @@
     <GroupDocsViewerUIApiInMemoryCache>3.1.1</GroupDocsViewerUIApiInMemoryCache>
     <GroupDocsViewerUIApiLocalStorage>3.1.2</GroupDocsViewerUIApiLocalStorage>
     <GroupDocsViewerUIApiCloudStorage>3.1.0</GroupDocsViewerUIApiCloudStorage>
-    <GroupDocsViewerUICore>3.1.4</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>3.1.17</GroupDocsViewerUISelfHostApi>
-    <GroupDocsViewerUICloudApi>3.1.3</GroupDocsViewerUICloudApi>
+    <GroupDocsViewerUICore>3.1.5</GroupDocsViewerUICore>
+    <GroupDocsViewerUISelfHostApi>3.1.18</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUICloudApi>3.1.4</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>

--- a/src/GroupDocs.Viewer.UI.Cloud.Api/Extensions/MvcBuilderExtensions.cs
+++ b/src/GroupDocs.Viewer.UI.Cloud.Api/Extensions/MvcBuilderExtensions.cs
@@ -11,8 +11,10 @@ using GroupDocs.Viewer.UI.Cloud.Api.Viewers;
 using GroupDocs.Viewer.UI.Core.Caching;
 using GroupDocs.Viewer.UI.Core.Caching.Implementation;
 using GroupDocs.Viewer.UI.Core.FileCaching;
+using GroupDocs.Viewer.UI.Core.PageFormatting;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -63,6 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddTransient<HtmlWithExternalResourcesViewer>();
             builder.Services.AddTransient<IAsyncLock, AsyncDuplicateLock>();
             builder.Services.AddTransient<IFileCache, NoopFileCache>();
+            builder.Services.TryAddSingleton<IPageFormatter, NoopPageFormatter>();
             
             builder.Services.AddTransient<IViewer>(factory =>
             {

--- a/src/GroupDocs.Viewer.UI.Core/Entities/HtmlPage.cs
+++ b/src/GroupDocs.Viewer.UI.Core/Entities/HtmlPage.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 
 namespace GroupDocs.Viewer.UI.Core.Entities
 {
@@ -9,6 +8,11 @@ namespace GroupDocs.Viewer.UI.Core.Entities
 
         public override string GetContent() =>
             Encoding.UTF8.GetString(Data);
+
+        public override void SetContent(string contents)
+        {
+            Data = Encoding.UTF8.GetBytes(contents);
+        }
 
         public HtmlPage(int pageNumber, byte[] data) 
             : base(pageNumber, data)

--- a/src/GroupDocs.Viewer.UI.Core/Entities/JpgPage.cs
+++ b/src/GroupDocs.Viewer.UI.Core/Entities/JpgPage.cs
@@ -1,13 +1,25 @@
 ﻿using System;
+using System.Text;
 
 namespace GroupDocs.Viewer.UI.Core.Entities
 {
     public class JpgPage : Page
     {
+        const string DATA_IMAGE = "data:image/jpeg;base64,";
+
         public static string Extension => ".jpeg";
 
-        public override string GetContent() =>
-            "data:image/jpeg;base64," + Convert.ToBase64String(Data);
+        public override string GetContent()
+        {
+            return DATA_IMAGE + Convert.ToBase64String(Data);
+        }
+
+        public override void SetContent(string content)
+        {
+            this.Data = content.StartsWith(DATA_IMAGE) 
+                ? Encoding.UTF8.GetBytes(content) 
+                : Encoding.UTF8.GetBytes(content.Substring(DATA_IMAGE.Length - 1));
+        }
 
         public JpgPage(int pageNumber, byte[] data) 
             : base(pageNumber, data)

--- a/src/GroupDocs.Viewer.UI.Core/Entities/Page.cs
+++ b/src/GroupDocs.Viewer.UI.Core/Entities/Page.cs
@@ -25,9 +25,11 @@ namespace GroupDocs.Viewer.UI.Core.Entities
 
         public int PageNumber { get; }
 
-        public byte[] Data { get; }
+        public byte[] Data { get; protected set; }
 
         public abstract string GetContent();
+
+        public abstract void SetContent(string content);
 
         public void AddResource(PageResource pageResource)
         {

--- a/src/GroupDocs.Viewer.UI.Core/Entities/PngPage.cs
+++ b/src/GroupDocs.Viewer.UI.Core/Entities/PngPage.cs
@@ -1,13 +1,23 @@
 ﻿using System;
+using System.Text;
 
 namespace GroupDocs.Viewer.UI.Core.Entities
 {
     public class PngPage : Page
     {
+        const string DATA_IMAGE = "data:image/png;base64,";
+
         public static string Extension => ".png";
 
         public override string GetContent() =>
-            "data:image/png;base64," + Convert.ToBase64String(Data);
+            DATA_IMAGE + Convert.ToBase64String(Data);
+
+        public override void SetContent(string content)
+        {
+            this.Data = content.StartsWith(DATA_IMAGE) 
+                ? Encoding.UTF8.GetBytes(content) 
+                : Encoding.UTF8.GetBytes(content.Substring(DATA_IMAGE.Length - 1));
+        }
 
         public PngPage(int pageNumber, byte[] data) 
             : base(pageNumber, data)

--- a/src/GroupDocs.Viewer.UI.Core/IPageFormatter.cs
+++ b/src/GroupDocs.Viewer.UI.Core/IPageFormatter.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Core.Entities;
+
+namespace GroupDocs.Viewer.UI.Core;
+
+public interface IPageFormatter
+{
+    Task<Page> FormatAsync(FileCredentials fileCredentials, Page page);
+}

--- a/src/GroupDocs.Viewer.UI.Core/PageFormatting/NoopPageFormatter.cs
+++ b/src/GroupDocs.Viewer.UI.Core/PageFormatting/NoopPageFormatter.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using GroupDocs.Viewer.UI.Core.Entities;
+
+namespace GroupDocs.Viewer.UI.Core.PageFormatting;
+
+public class NoopPageFormatter : IPageFormatter
+{
+    public Task<Page> FormatAsync(FileCredentials fileCredentials, Page page) => 
+        Task.FromResult(page);
+}

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Extensions/MvcBuilderExtensions.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Extensions/MvcBuilderExtensions.cs
@@ -6,12 +6,14 @@ using GroupDocs.Viewer.UI.Core;
 using GroupDocs.Viewer.UI.Core.Caching;
 using GroupDocs.Viewer.UI.Core.Caching.Implementation;
 using GroupDocs.Viewer.UI.Core.FileCaching;
+using GroupDocs.Viewer.UI.Core.PageFormatting;
 using GroupDocs.Viewer.UI.SelfHost.Api;
 using GroupDocs.Viewer.UI.SelfHost.Api.Configuration;
 using GroupDocs.Viewer.UI.SelfHost.Api.Licensing;
 using GroupDocs.Viewer.UI.SelfHost.Api.Viewers;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -38,14 +40,9 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddSingleton<IViewerLicenser, ViewerLicenser>();
             builder.Services.AddTransient<IFileCache, NoopFileCache>();
             builder.Services.AddTransient<IAsyncLock, AsyncDuplicateLock>();
-            
-            ServiceDescriptor registeredFileTypeResolver = builder.Services.FirstOrDefault(
-                s => s.ServiceType == typeof(IFileTypeResolver));
-            if (registeredFileTypeResolver == null)
-            {
-                builder.Services.AddSingleton<IFileTypeResolver, FileExtensionFileTypeResolver>();
-            }
-
+            builder.Services.TryAddSingleton<IFileTypeResolver, FileExtensionFileTypeResolver>();
+            builder.Services.TryAddSingleton<IPageFormatter, NoopPageFormatter>();
+           
             builder.Services.AddTransient<HtmlWithEmbeddedResourcesViewer>();
             builder.Services.AddTransient<HtmlWithExternalResourcesViewer>();
             builder.Services.AddTransient<PngViewer>();

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithEmbeddedResourcesViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithEmbeddedResourcesViewer.cs
@@ -16,8 +16,8 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
         private readonly Config _config;
 
         public HtmlWithEmbeddedResourcesViewer(IOptions<Config> config, 
-            IViewerLicenser licenser, IFileStorage fileStorage, IFileTypeResolver fileTypeResolver)
-            : base(config, licenser, fileStorage, fileTypeResolver)
+            IViewerLicenser licenser, IFileStorage fileStorage, IFileTypeResolver fileTypeResolver, IPageFormatter pageFormatter)
+            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
         }

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithExternalResourcesViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithExternalResourcesViewer.cs
@@ -26,8 +26,9 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
             IOptions<UI.Api.Configuration.Options> options,
             IViewerLicenser licenser,
             IFileStorage fileStorage,
-            IFileTypeResolver fileTypeResolver) 
-            : base(config, licenser, fileStorage, fileTypeResolver)
+            IFileTypeResolver fileTypeResolver,
+            IPageFormatter pageFormatter) 
+            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
             _options = options.Value;

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/JpgViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/JpgViewer.cs
@@ -16,8 +16,11 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
         private readonly Config _config;
 
         public JpgViewer(IOptions<Config> config,
-            IViewerLicenser licenser, IFileStorage fileStorage, IFileTypeResolver fileTypeResolver)
-            : base(config, licenser, fileStorage, fileTypeResolver)
+            IViewerLicenser licenser, 
+            IFileStorage fileStorage, 
+            IFileTypeResolver fileTypeResolver,
+            IPageFormatter pageFormatter)
+            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
         }

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/PngViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/PngViewer.cs
@@ -16,8 +16,11 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
         private readonly Config _config;
 
         public PngViewer(IOptions<Config> config,
-            IViewerLicenser licenser, IFileStorage fileStorage, IFileTypeResolver fileTypeResolver)
-            : base(config, licenser, fileStorage, fileTypeResolver)
+            IViewerLicenser licenser, 
+            IFileStorage fileStorage, 
+            IFileTypeResolver fileTypeResolver, 
+            IPageFormatter pageFormatter)
+            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
         }


### PR DESCRIPTION
Added new interface that can be used for implementation of pages post-processing e.g. links invalidation in the output HTML

```cs
public interface IPageFormatter
{
    Task<Page> FormatAsync(FileCredentials fileCredentials, Page page);
}
```

Example:
```cs
services.AddSingleton<IPageFormatter, InvalidateLinksPageFormatter>();

// ...

public class InvalidateLinksPageFormatter : IPageFormatter
{
    public Task<Page> FormatAsync(FileCredentials fileCredentials, Page page)
    {
        var html = page.GetContent();

        var regex = new Regex(
            "href=['\"](?<href>.*?)['\"]", RegexOptions.IgnoreCase);

        var formattedHtml = regex.Replace(html, match =>
        {
            var link = match.Value;
            var href = match.Groups["href"].Value;
            return link.Replace(href, "javascript:;");
        });

        page.SetContent(formattedHtml);

        return Task.FromResult(page);
    }
}
```

