### PR TITLE
Updated GroupDocs.Viewer to 22.11

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>22.9</GroupDocsViewer>
+    <GroupDocsViewer>22.11</GroupDocsViewer>
     <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.3</SkiaSharpNativeAssetsLinuxNoDependencies>
 
     <MicrosoftExtensionsHttp>6.0.0</MicrosoftExtensionsHttp>
@@ -40,7 +40,7 @@
     <GroupDocsViewerUIApiLocalStorage>6.0.0</GroupDocsViewerUIApiLocalStorage>
     <GroupDocsViewerUIApiCloudStorage>6.0.1</GroupDocsViewerUIApiCloudStorage>
     <GroupDocsViewerUICore>6.0.0</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>6.0.1</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>6.0.2</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>6.0.0</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
GroupDocs.Viewer for .NET Release Notes https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-22-11-release-notes/