### PR TITLE
Rolled back Viewer to 22.11. Added internal caching.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>23.1</GroupDocsViewer>
+    <GroupDocsViewer>22.11</GroupDocsViewer>
+    <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.3</SkiaSharpNativeAssetsLinuxNoDependencies>
 
     <MicrosoftExtensionsHttp>6.0.0</MicrosoftExtensionsHttp>
     <MicrosoftAspNetCoreMvcCore>2.2.5</MicrosoftAspNetCoreMvcCore>
@@ -44,7 +45,7 @@
     <GroupDocsViewerUIApiAzureStorage>6.0.0</GroupDocsViewerUIApiAzureStorage>
     <GroupDocsViewerUIApiAwsS3Storage>6.0.0</GroupDocsViewerUIApiAwsS3Storage>
     <GroupDocsViewerUICore>6.0.1</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>6.0.4</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>6.0.5</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>6.0.1</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>

--- a/samples/GroupDocs.Viewer.UI.Sample/Program.cs
+++ b/samples/GroupDocs.Viewer.UI.Sample/Program.cs
@@ -1,7 +1,11 @@
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
-    .AddGroupDocsViewerUI();
+    .AddGroupDocsViewerUI(config =>
+    {
+        //Preload first three pages
+        config.SetPreloadPageCount(3);
+    });
 
 builder.Services
     .AddControllers()

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Configuration/Config.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Configuration/Config.cs
@@ -12,6 +12,7 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Configuration
         internal readonly PngViewOptions PngViewOptions = new PngViewOptions();
         internal readonly JpgViewOptions JpgViewOptions = new JpgViewOptions();
         internal readonly PdfViewOptions PdfViewOptions = new PdfViewOptions();
+        internal readonly InternalCacheOptions InternalCacheOptions = InternalCacheOptions.CacheForFiveMinutes;
 
         public Config SetLicensePath(string licensePath)
         {
@@ -46,6 +47,20 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Configuration
         public Config ConfigurePdfViewOptions(Action<PdfViewOptions> setupOptions)
         {
             setupOptions?.Invoke(PdfViewOptions);
+            return this;
+        }
+
+        /// <summary>
+        /// Call this method to configure internal objects caching.
+        /// Internal caching makes objects available between requests to speed up rendering when document is rendered in chunks.
+        /// Default cache entry lifetime is 5 minutes.
+        /// Internal cache is based on MemoryCache (ConcurrentDictionary), so the object are stored in memory. 
+        /// </summary>
+        /// <param name="setupOptions">Setup delegate.</param>
+        /// <returns>This instance.</returns>
+        public Config ConfigureInternalCaching(Action<InternalCacheOptions> setupOptions)
+        {
+            setupOptions?.Invoke(InternalCacheOptions);
             return this;
         }
     }

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Configuration/InternalCacheOptions.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Configuration/InternalCacheOptions.cs
@@ -1,0 +1,40 @@
+﻿namespace GroupDocs.Viewer.UI.SelfHost.Api.Configuration
+{
+    /// <summary>
+    /// This class contains options for internal objects caching.
+    /// </summary>
+    public class InternalCacheOptions
+    {
+        public static readonly InternalCacheOptions CacheForFiveMinutes =
+            new InternalCacheOptions { IsCacheEnabled = true, CacheEntryExpirationTimeoutMinutes = 5 };
+
+        internal bool IsCacheEnabled { get; private set; }
+
+        internal bool IsCacheDisabled => !IsCacheEnabled;
+
+        internal int CacheEntryExpirationTimeoutMinutes { get; private set; }
+
+        /// <summary>
+        /// Turn of internal caching.
+        /// By default caching is enabled.
+        /// </summary>
+        /// <returns>This instance.</returns>
+        public InternalCacheOptions DisableInternalCache()
+        {
+            IsCacheEnabled = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Set the expiration timeout of each cache entry in minutes.
+        /// The default value is 5 minutes.
+        /// </summary>
+        /// <param name="cacheEntryExpirationTimeoutMinutes">The expiration timeout in minutes.</param>
+        /// <returns>This instance.</returns>
+        public InternalCacheOptions SetCacheEntryExpirationTimeoutMinutes(int cacheEntryExpirationTimeoutMinutes)
+        {
+            CacheEntryExpirationTimeoutMinutes = cacheEntryExpirationTimeoutMinutes;
+            return this;
+        }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/GroupDocs.Viewer.UI.SelfHost.Api.csproj
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/GroupDocs.Viewer.UI.SelfHost.Api.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="GroupDocs.Viewer" Version="$(GroupDocsViewer)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCore)" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="$(SkiaSharpNativeAssetsLinuxNoDependencies)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/InternalCaching/IInternalCache.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/InternalCaching/IInternalCache.cs
@@ -1,0 +1,11 @@
+﻿using GroupDocs.Viewer.UI.Core.Entities;
+
+namespace GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching
+{
+    public interface IInternalCache
+    {
+        bool TryGet(FileCredentials fileCredentials, out Viewer viewer);
+
+        void Set(FileCredentials fileCredentials, Viewer entry);
+    }
+}

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/InternalCaching/Implementation/InMemoryInternalCache.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/InternalCaching/Implementation/InMemoryInternalCache.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading;
+using GroupDocs.Viewer.UI.Core.Entities;
+using GroupDocs.Viewer.UI.SelfHost.Api.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+// ReSharper disable once CheckNamespace
+namespace GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching
+{
+    public class InMemoryInternalCache : IInternalCache
+    {
+        private readonly IMemoryCache _cache;
+        private readonly InternalCacheOptions _options;
+
+        public InMemoryInternalCache(IMemoryCache cache, InternalCacheOptions options)
+        {
+            _cache = cache;
+            _options = options;
+        }
+
+        public bool TryGet(FileCredentials fileCredentials, out Viewer viewer)
+        {
+            var key = GetKey(fileCredentials);
+            if (_cache.TryGetValue(key, out object obj))
+            {
+                viewer = (Viewer)obj;
+                return true;
+            }
+
+            viewer = null;
+            return false;
+        }
+
+        public void Set(FileCredentials fileCredentials, Viewer entry)
+        {
+            MemoryCacheEntryOptions entryOptions;
+            string key = GetKey(fileCredentials);
+
+            if (_options.CacheEntryExpirationTimeoutMinutes > 0)
+            {
+                var cts = GetOrCreateCancellationTokenSource(key);
+                entryOptions = CreateCacheEntryOptions(cts);
+            }
+            else
+            {
+                entryOptions = CreateCacheEntryOptions();
+            }
+
+            _cache.Set(key, entry, entryOptions);
+        }
+
+        private string GetKey(FileCredentials fileCredentials) => 
+            $"{fileCredentials.FilePath}_{fileCredentials.Password}__VC";
+
+        private CancellationTokenSource GetOrCreateCancellationTokenSource(string key)
+        {
+            var ctsCacheKey = $"{key}_CTS";
+
+            var cts = _cache.Get<CancellationTokenSource>(ctsCacheKey);
+            if (cts == null || cts.IsCancellationRequested)
+            {
+                using (var ctsEntry = _cache.CreateEntry(ctsCacheKey))
+                {
+                    cts = CreateCancellationTokenSource();
+
+                    ctsEntry.Value = cts;
+                    ctsEntry.AddExpirationToken(CreateCancellationChangeToken(cts));
+                }
+            }
+
+            return cts;
+        }
+
+        private MemoryCacheEntryOptions CreateCacheEntryOptions(CancellationTokenSource cts)
+        {
+            var entryOptions = new MemoryCacheEntryOptions();
+            entryOptions.AddExpirationToken(CreateCancellationChangeToken(cts));
+            entryOptions.RegisterPostEvictionCallback(
+                callback: (key, value, evictionReason, state) =>
+                {
+                    if (value is Viewer viewer)
+                        viewer.Dispose();
+                });
+
+            return entryOptions;
+        }
+
+        private MemoryCacheEntryOptions CreateCacheEntryOptions()
+        {
+            var entryOptions = new MemoryCacheEntryOptions();
+            return entryOptions;
+        }
+
+        private CancellationChangeToken CreateCancellationChangeToken(CancellationTokenSource cancellationTokenSource)
+            => new CancellationChangeToken(cancellationTokenSource.Token);
+
+        private CancellationTokenSource CreateCancellationTokenSource() =>
+            new CancellationTokenSource(TimeSpan.FromMinutes(_options.CacheEntryExpirationTimeoutMinutes));
+    }
+}

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/InternalCaching/Implementation/NoopInternalCache.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/InternalCaching/Implementation/NoopInternalCache.cs
@@ -1,0 +1,16 @@
+﻿using GroupDocs.Viewer.UI.Core.Entities;
+
+// ReSharper disable once CheckNamespace
+namespace GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching
+{
+    public class NoopInternalCache : IInternalCache
+    {
+        public bool TryGet(FileCredentials fileCredentials, out Viewer viewer)
+        {
+            viewer = null;
+            return false;
+        }
+
+        public void Set(FileCredentials fileCredentials, Viewer entry) { }
+    }
+}

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithEmbeddedResourcesViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithEmbeddedResourcesViewer.cs
@@ -4,6 +4,7 @@ using GroupDocs.Viewer.Options;
 using GroupDocs.Viewer.UI.Core;
 using GroupDocs.Viewer.UI.Core.Entities;
 using GroupDocs.Viewer.UI.SelfHost.Api.Configuration;
+using GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching;
 using GroupDocs.Viewer.UI.SelfHost.Api.Licensing;
 using GroupDocs.Viewer.UI.SelfHost.Api.Viewers.Extensions;
 using Microsoft.Extensions.Options;
@@ -15,9 +16,14 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
     {
         private readonly Config _config;
 
-        public HtmlWithEmbeddedResourcesViewer(IOptions<Config> config, 
-            IViewerLicenser licenser, IFileStorage fileStorage, IFileTypeResolver fileTypeResolver, IPageFormatter pageFormatter)
-            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
+        public HtmlWithEmbeddedResourcesViewer(
+            IOptions<Config> config, 
+            IViewerLicenser licenser, 
+            IInternalCache viewerCache,
+            IFileStorage fileStorage, 
+            IFileTypeResolver fileTypeResolver, 
+            IPageFormatter pageFormatter) 
+            : base(config, licenser, viewerCache, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
         }

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithExternalResourcesViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/HtmlWithExternalResourcesViewer.cs
@@ -9,6 +9,7 @@ using GroupDocs.Viewer.UI.Api;
 using GroupDocs.Viewer.UI.Core;
 using GroupDocs.Viewer.UI.Core.Entities;
 using GroupDocs.Viewer.UI.SelfHost.Api.Configuration;
+using GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching;
 using GroupDocs.Viewer.UI.SelfHost.Api.Licensing;
 using GroupDocs.Viewer.UI.SelfHost.Api.Viewers.Extensions;
 using Microsoft.Extensions.Options;
@@ -25,10 +26,11 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
             IOptions<Config> config,
             IOptions<UI.Api.Configuration.Options> options,
             IViewerLicenser licenser,
+            IInternalCache internalCache,
             IFileStorage fileStorage,
             IFileTypeResolver fileTypeResolver,
             IPageFormatter pageFormatter) 
-            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
+            : base(config, licenser, internalCache, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
             _options = options.Value;

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/JpgViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/JpgViewer.cs
@@ -4,6 +4,7 @@ using GroupDocs.Viewer.Options;
 using GroupDocs.Viewer.UI.Core;
 using GroupDocs.Viewer.UI.Core.Entities;
 using GroupDocs.Viewer.UI.SelfHost.Api.Configuration;
+using GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching;
 using GroupDocs.Viewer.UI.SelfHost.Api.Licensing;
 using GroupDocs.Viewer.UI.SelfHost.Api.Viewers.Extensions;
 using Microsoft.Extensions.Options;
@@ -16,11 +17,12 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
         private readonly Config _config;
 
         public JpgViewer(IOptions<Config> config,
-            IViewerLicenser licenser, 
+            IViewerLicenser licenser,
+            IInternalCache internalCache,
             IFileStorage fileStorage, 
             IFileTypeResolver fileTypeResolver,
             IPageFormatter pageFormatter)
-            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
+            : base(config, licenser, internalCache, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
         }

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/PngViewer.cs
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/Viewers/PngViewer.cs
@@ -4,6 +4,7 @@ using GroupDocs.Viewer.Options;
 using GroupDocs.Viewer.UI.Core;
 using GroupDocs.Viewer.UI.Core.Entities;
 using GroupDocs.Viewer.UI.SelfHost.Api.Configuration;
+using GroupDocs.Viewer.UI.SelfHost.Api.InternalCaching;
 using GroupDocs.Viewer.UI.SelfHost.Api.Licensing;
 using GroupDocs.Viewer.UI.SelfHost.Api.Viewers.Extensions;
 using Microsoft.Extensions.Options;
@@ -16,11 +17,12 @@ namespace GroupDocs.Viewer.UI.SelfHost.Api.Viewers
         private readonly Config _config;
 
         public PngViewer(IOptions<Config> config,
-            IViewerLicenser licenser, 
+            IViewerLicenser licenser,
+            IInternalCache internalCache,
             IFileStorage fileStorage, 
             IFileTypeResolver fileTypeResolver, 
             IPageFormatter pageFormatter)
-            : base(config, licenser, fileStorage, fileTypeResolver, pageFormatter)
+            : base(config, licenser, internalCache, fileStorage, fileTypeResolver, pageFormatter)
         {
             _config = config.Value;
         }


### PR DESCRIPTION
This pull request contains two main changes 
1. Rolled back Viewer to 22.11 due to significantly decreased performance when rendering PDF files
2. Added internal caching of `Viewer` instance. Internal caching is enabled by default and can be disabled through configuration 
```cs
builder.Services
    .AddControllers()
    .AddGroupDocsViewerSelfHostApi(config =>
    {
        config.ConfigureInternalCaching(options =>
        {
            options.DisableInternalCache();
        });
    })
```

You can also change the internal cache entry lifetime. By default, it is set to `5` minutes.

```cs
builder.Services
    .AddControllers()
    .AddGroupDocsViewerSelfHostApi(config =>
    {
        config.ConfigureInternalCaching(options =>
        {
            options.SetCacheEntryExpirationTimeoutMinutes(10); 
        });
    })
```
