### PR TITLE
Updated GroupDocs.Viewer to 23.3

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,8 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>22.11</GroupDocsViewer>
-    <SkiaSharpNativeAssetsLinuxNoDependencies>2.80.3</SkiaSharpNativeAssetsLinuxNoDependencies>
+    <GroupDocsViewer>23.3</GroupDocsViewer>
 
     <MicrosoftExtensionsHttp>6.0.0</MicrosoftExtensionsHttp>
     <MicrosoftAspNetCoreMvcCore>2.2.5</MicrosoftAspNetCoreMvcCore>
@@ -45,7 +44,7 @@
     <GroupDocsViewerUIApiAzureStorage>6.0.0</GroupDocsViewerUIApiAzureStorage>
     <GroupDocsViewerUIApiAwsS3Storage>6.0.0</GroupDocsViewerUIApiAwsS3Storage>
     <GroupDocsViewerUICore>6.0.1</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>6.0.8</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>6.0.9</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>6.0.3</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
GroupDocs.Viewer for .NET 23.3 has been published.
Release notes: https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-23-3-release-notes/