### PR TITLE
Updated GroupDocs.Viewer to 23.11

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>23.10</GroupDocsViewer>
+    <GroupDocsViewer>23.11</GroupDocsViewer>
 
     <MicrosoftExtensionsHttp>6.0.0</MicrosoftExtensionsHttp>
     <MicrosoftAspNetCoreMvcCore>2.2.5</MicrosoftAspNetCoreMvcCore>
@@ -44,7 +44,7 @@
     <GroupDocsViewerUIApiAzureStorage>6.0.2</GroupDocsViewerUIApiAzureStorage>
     <GroupDocsViewerUIApiAwsS3Storage>6.0.2</GroupDocsViewerUIApiAwsS3Storage>
     <GroupDocsViewerUICore>6.0.4</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>6.0.17</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>6.0.18</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>6.0.6</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Full list of changes in this release

| Key | Category | Summary |
| --- | --- | --- |
|VIEWERNET&#8209;4538|Feature|Add support for reading license from embedded resources|
|VIEWERNET&#8209;4474|Fix|A generic error occurred in GDI+|
|VIEWERNET&#8209;4237|Fix|Colour gradients lost in Vectors|
|VIEWERNET&#8209;4209|Fix|PdfOptions.RenderTextAsImage = false causes slow loading|
|VIEWERNET&#8209;2277|Fix|Resource loading timeout is not working|
|VIEWERNET&#8209;3430|Fix|"Font embedding is prohibited because of font license restrictions" exception when rendering OXPS file|
|VIEWERNET&#8209;2700|Fix|Null reference exception when Load and Save Epub/PDF document to PDF without license in Linux|

## Major features

This release includes the following features:

* [Add support for reading license from embedded resources](#Add-support-for-reading-license-from-embedded-resources)
* [Bypass embedded font license verification in XPS and OXPS files](#bypass-embedded-font-license-verification-in-xps-and-oxps-files)
* [Wrap images in SVG when rendering PDF and Page Layout files](#wrap-images-in-svg-when-rendering-pdf-and-page-layout-files)

### Add support for reading license from embedded resources

When utilizing an embedded license, you can specify the license name. It's essential to include the license file as an embedded resource within your project. Subsequently, you can exclusively reference the license by its name, ensuring that the string passed to the `SetLicense` method perfectly matches the file name included in the embedded resource.

```cs
//set license from embedded resource
License license = new License();
license.SetLicense("GroupDocs.Viewer.lic");
```

### Bypass font license verification when rendering XPS and OXPS files

In case an XPS or OXPS file contains a font that can't be embedded due to licensing restrictions, an exception is thrown at runtime. If you have a license for such a font, you can enable the `PdfOptions.DisableFontLicenseVerifications` option to bypass font license verification.

```cs
using (Viewer viewer = new Viewer("resume.oxps"))
{
    HtmlViewOptions viewOptions = HtmlViewOptions.ForEmbeddedResources();
    options.PdfOptions.DisableFontLicenseVerifications = true;
    viewer.View(viewOptions);
}
```

### Wrap images in SVG when rendering PDF and Page Layout files

By default, when rendering to [PDF and Page Layout file formats](https://docs.groupdocs.com/viewer/net/supported-document-formats/#pdf-and-page-layout-file-formats), all the images are rendered as one PNG image. The rendered PNG image is used as the background for the output HTML document.

In this version we added new option `PdfOptions.WrapImagesInSvg`. When enabled each image in the output HTML document will be wrapped in SVG tag to improve output quality.
This option is supported when rendering PDF and Page Layout file formats to HTML with embedded and external resources. 

```cs
using (Viewer viewer = new Viewer("resume.pdf"))
{
    HtmlViewOptions viewOptions = HtmlViewOptions.ForEmbeddedResources();
    viewOptions.PdfOptions.WrapImagesInSvg = true;

    viewer.View(viewOptions);
}
```