### PR TITLE
Updated GroupDocs.Viewer for .NET to 24.1

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <GroupDocsViewer>23.12</GroupDocsViewer>
+    <GroupDocsViewer>24.1</GroupDocsViewer>
 
     <MicrosoftExtensionsHttp>6.0.0</MicrosoftExtensionsHttp>
     <MicrosoftAspNetCoreMvcCore>2.2.5</MicrosoftAspNetCoreMvcCore>
@@ -44,7 +44,7 @@
     <GroupDocsViewerUIApiAzureStorage>6.0.2</GroupDocsViewerUIApiAzureStorage>
     <GroupDocsViewerUIApiAwsS3Storage>6.0.2</GroupDocsViewerUIApiAwsS3Storage>
     <GroupDocsViewerUICore>6.0.4</GroupDocsViewerUICore>
-    <GroupDocsViewerUISelfHostApi>6.0.19</GroupDocsViewerUISelfHostApi>
+    <GroupDocsViewerUISelfHostApi>6.0.20</GroupDocsViewerUISelfHostApi>
     <GroupDocsViewerUICloudApi>6.0.6</GroupDocsViewerUICloudApi>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updated GroupDocs.Viewer for .NET to 24.1 that fixes issue #51.

See also [GroupDocs.Viewer for .NET 24.1 Release Notes](https://releases.groupdocs.com/viewer/net/release-notes/2024/groupdocs-viewer-for-net-24-1-release-notes/).