### PR TITLE
Merge `8.0.7` branch into `main`

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -35,18 +35,18 @@
 	</PropertyGroup>
 
 	<PropertyGroup Label="GroupDocs.Viewer UI Package Versions">
-		<GroupDocsViewerUI>8.0.6</GroupDocsViewerUI>
-		<GroupDocsViewerUIApi>8.0.6</GroupDocsViewerUIApi>
-		<GroupDocsViewerUIApiLocalCache>8.0.6</GroupDocsViewerUIApiLocalCache>
-		<GroupDocsViewerUIApiInMemoryCache>8.0.6</GroupDocsViewerUIApiInMemoryCache>
-		<GroupDocsViewerUIApiLocalStorage>8.0.6</GroupDocsViewerUIApiLocalStorage>
-		<GroupDocsViewerUIApiCloudStorage>8.0.6</GroupDocsViewerUIApiCloudStorage>
-		<GroupDocsViewerUIApiAzureStorage>8.0.6</GroupDocsViewerUIApiAzureStorage>
-		<GroupDocsViewerUIApiAwsS3Storage>8.0.6</GroupDocsViewerUIApiAwsS3Storage>
-		<GroupDocsViewerUICore>8.0.6</GroupDocsViewerUICore>
-		<GroupDocsViewerUISelfHostApi>8.0.6</GroupDocsViewerUISelfHostApi>
-		<GroupDocsViewerUISelfHostApiCrossPlatform>8.0.6</GroupDocsViewerUISelfHostApiCrossPlatform>
-		<GroupDocsViewerUICloudApi>8.0.6</GroupDocsViewerUICloudApi>
+		<GroupDocsViewerUI>8.0.7</GroupDocsViewerUI>
+		<GroupDocsViewerUIApi>8.0.7</GroupDocsViewerUIApi>
+		<GroupDocsViewerUIApiLocalCache>8.0.7</GroupDocsViewerUIApiLocalCache>
+		<GroupDocsViewerUIApiInMemoryCache>8.0.7</GroupDocsViewerUIApiInMemoryCache>
+		<GroupDocsViewerUIApiLocalStorage>8.0.7</GroupDocsViewerUIApiLocalStorage>
+		<GroupDocsViewerUIApiCloudStorage>8.0.7</GroupDocsViewerUIApiCloudStorage>
+		<GroupDocsViewerUIApiAzureStorage>8.0.7</GroupDocsViewerUIApiAzureStorage>
+		<GroupDocsViewerUIApiAwsS3Storage>8.0.7</GroupDocsViewerUIApiAwsS3Storage>
+		<GroupDocsViewerUICore>8.0.7</GroupDocsViewerUICore>
+		<GroupDocsViewerUISelfHostApi>8.0.7</GroupDocsViewerUISelfHostApi>
+		<GroupDocsViewerUISelfHostApiCrossPlatform>8.0.7</GroupDocsViewerUISelfHostApiCrossPlatform>
+		<GroupDocsViewerUICloudApi>8.0.7</GroupDocsViewerUICloudApi>
 	</PropertyGroup>
 
 	<PropertyGroup Label="NuGet Common Settings">

--- a/src/GroupDocs.Viewer.UI.API/Utils/ApiUrlBuilder.cs
+++ b/src/GroupDocs.Viewer.UI.API/Utils/ApiUrlBuilder.cs
@@ -22,9 +22,19 @@ namespace GroupDocs.Viewer.UI.Api.Utils
         {
             var request = _httpContextAccessor.HttpContext.Request;
 
-            return string.IsNullOrEmpty(_options.ApiDomain)
-                ? $"{request.Scheme}://{request.Host}"
-                : _options.ApiDomain;
+            if (string.IsNullOrEmpty(_options.ApiDomain))
+            {
+                var baseUrl = $"{request.Scheme}://{request.Host}";
+
+                if (!string.IsNullOrEmpty(request.PathBase))
+                {
+                    baseUrl += request.PathBase.Value;
+                }
+
+                return baseUrl;
+            }
+
+            return _options.ApiDomain;
         }
 
         public string BuildPageUrl(string file, int page, string extension) =>

--- a/src/GroupDocs.Viewer.UI.Api.AwsS3.Storage/GroupDocs.Viewer.UI.Api.AwsS3.Storage.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.AwsS3.Storage/GroupDocs.Viewer.UI.Api.AwsS3.Storage.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Api.AzureBlob.Storage/GroupDocs.Viewer.UI.Api.AzureBlob.Storage.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.AzureBlob.Storage/GroupDocs.Viewer.UI.Api.AzureBlob.Storage.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.Cloud.Storage/GroupDocs.Viewer.UI.Api.Cloud.Storage.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Api.InMemory.Cache/GroupDocs.Viewer.UI.Api.InMemory.Cache.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.InMemory.Cache/GroupDocs.Viewer.UI.Api.InMemory.Cache.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Api.Local.Cache/GroupDocs.Viewer.UI.Api.Local.Cache.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.Local.Cache/GroupDocs.Viewer.UI.Api.Local.Cache.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Api.Local.Storage/GroupDocs.Viewer.UI.Api.Local.Storage.csproj
+++ b/src/GroupDocs.Viewer.UI.Api.Local.Storage/GroupDocs.Viewer.UI.Api.Local.Storage.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Cloud.Api/GroupDocs.Viewer.UI.Cloud.Api.csproj
+++ b/src/GroupDocs.Viewer.UI.Cloud.Api/GroupDocs.Viewer.UI.Cloud.Api.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.Core/GroupDocs.Viewer.UI.Core.csproj
+++ b/src/GroupDocs.Viewer.UI.Core/GroupDocs.Viewer.UI.Core.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api.CrossPlatform/GroupDocs.Viewer.UI.SelfHost.Api.CrossPlatform.csproj
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api.CrossPlatform/GroupDocs.Viewer.UI.SelfHost.Api.CrossPlatform.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GroupDocs.Viewer.UI.SelfHost.Api/GroupDocs.Viewer.UI.SelfHost.Api.csproj
+++ b/src/GroupDocs.Viewer.UI.SelfHost.Api/GroupDocs.Viewer.UI.SelfHost.Api.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="images\icon.png" />
+	<None Include="README.md" pack="true" PackagePath="." />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# ✨ PR Overview

This PR adds support for `PathBase` for the self-hosted API and adds READMEs to NuGet packages.

## 🛠️ Changes

### 1️⃣ Add Support for `PathBase` to Self-Hosted API

This issue was reported by one of our users in the [Free Support Forum](https://forum.groupdocs.com/).  
The `PathBase` value was being ignored during the stage when the API endpoint was generated.

For example, when running the app at a specific path—set during app composition in `Program.cs`:

```cs
var builder = WebApplication.CreateBuilder(args);

builder.Services
    .AddControllers()
    .AddGroupDocsViewerSelfHostApi();

var app = builder.Build();

app.UsePathBase("/TenantA");

app
    .UseRouting()
    .UseEndpoints(endpoints =>
    {
        endpoints.MapGroupDocsViewerApi();
    });

app.Run();
```

The API endpoint was not properly generated because the `PathBase` value (in this example, `/TenantA`) was ignored.  
This issue has been fixed, and now `PathBase` is correctly taken into account when specified.

---

### 2️⃣ Add README to NuGet Packages

README files are now included in each NuGet package, and will appear on the package's page on NuGet.org.
